### PR TITLE
Fix deprecations.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ Lazy
 LNR
 JuliaParser
 MacroTools
+Compat

--- a/src/CodeTools.jl
+++ b/src/CodeTools.jl
@@ -2,7 +2,7 @@ module CodeTools
 
 using MacroTools
 
-using LNR, Lazy, Requires
+using LNR, Lazy, Requires, Compat
 
 include("parse/parse.jl")
 include("eval.jl")

--- a/src/doc.jl
+++ b/src/doc.jl
@@ -4,7 +4,7 @@ function thingorfunc(code, cursor, mod = Main; name = getqualifiedname(code, cur
 end
 
 function doc(code, cursor, mod = Main)
-  docs = String[]
+  docs = UTF8String[]
   name = getqualifiedname(code, cursor)
 
   thing = thingorfunc(code, cursor, mod; name = name)
@@ -25,7 +25,7 @@ function texcommands(name, code, cursor)
     chars = line[max(c - 1, 1):min(c, length(line))]
   end
 
-  syms = String[]
+  syms = UTF8String[]
   for char in chars
     cmd = get(reverse_latex_commands, char, "")
     isempty(cmd) || push!(syms, "  $(char)\u00a0 $(cmd)")

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -15,20 +15,20 @@ end
 getthing(name::Vector{Symbol}, default = nothing) =
   getthing(Main, name, default)
 
-getthing(mod::Module, name::String, default = nothing) =
+getthing(mod::Module, name::AbstractString, default = nothing) =
   name == "" ?
     default :
     @as _ name split(_, ".", keep=false) map(symbol, _) getthing(mod, _, default)
 
-getthing(name::String, default = nothing) =
+getthing(name::AbstractString, default = nothing) =
   getthing(Main, name, default)
 
-getthing(::Nothing, default) = default
-getthing(mod, ::Nothing, default) = default
+getthing(::Void, default) = default
+getthing(mod, ::Void, default) = default
 
 # include_string with line numbers
 
-function Base.include_string(s::String, fname::String, line::Integer)
+function Base.include_string(s::AbstractString, fname::AbstractString, line::Integer)
   include_string("\n"^(line-1)*s, fname)
 end
 

--- a/src/module.jl
+++ b/src/module.jl
@@ -21,7 +21,7 @@ files(dir) =
 dirs(dir) =
   @>> dir readdir′ filter!(f->!beginswith(f, ".")) map!(f->joinpath(dir, f)) filter!(isdir′)
 
-jl_files(dir::String) = @>> dir files filter!(f->endswith(f, ".jl"))
+jl_files(dir::AbstractString) = @>> dir files filter!(f->endswith(f, ".jl"))
 
 function jl_files(set)
   files = Set{UTF8String}()
@@ -57,7 +57,7 @@ end
 Takes a given Julia source file and another (absolute) path, gives the
 line on which the path is included in the file or 0.
 """
-function includeline(file::String, included_file::String)
+function includeline(file::AbstractString, included_file::AbstractString)
   i = 0
   open(file) do io
     for (index, line) in enumerate(eachline(io))
@@ -75,7 +75,7 @@ end
 Takes an absolute path to a file and returns the (file, line) where that
 file is included or nothing.
 """
-function find_include(path::String)
+function find_include(path::AbstractString)
   for file in @> path dirname dirsnearby jl_files
     line = includeline(file, path)
     line > 0 && (return file, line)
@@ -86,7 +86,7 @@ end
 Takes an absolute path to a file and returns a string
 representing the module it belongs to.
 """
-function filemodule(path::String)
+function filemodule(path::AbstractString)
   loc = find_include(path)
   if loc != nothing
     file, line = loc

--- a/src/parse/block.jl
+++ b/src/parse/block.jl
@@ -13,7 +13,7 @@ function walkback(code::Vector, line)
   return line
 end
 
-closed(code::String) = scope(code).kind == :toplevel
+closed(code::AbstractString) = scope(code).kind == :toplevel
 
 # Scan to the start of the next block, find the end of
 # this one.

--- a/src/parse/parse.jl
+++ b/src/parse/parse.jl
@@ -6,8 +6,8 @@ lines(s) = split(s, "\n")
 codemodule(code, pos) =
   @as _ code scopes(_, pos) filter(s->s.kind==:module, _) map(s->s.name, _) join(_, ".")
 
-precursor(s::String, i) = join(collect(s)[1:min(i-1, end)])
-postcursor(s::String, i) = join(collect(s)[i:end])
+precursor(s::AbstractString, i) = join(collect(s)[1:min(i-1, end)])
+postcursor(s::AbstractString, i) = join(collect(s)[i:end])
 
 """
 Retreive the appropriate block of code as well as well
@@ -27,7 +27,7 @@ function matchorempty(args...)
   result == nothing ? "" : result.match
 end
 
-function getqualifiedname(str::String, index::Integer)
+function getqualifiedname(str::AbstractString, index::Integer)
   pre = precursor(str, index)
   post = postcursor(str, index)
 
@@ -44,9 +44,9 @@ function getqualifiedname(str::String, index::Integer)
 end
 
 # could be more efficient
-getqualifiedname(str::String, cursor) = getqualifiedname(lines(str)[cursor.line], cursor.column)
+getqualifiedname(str::AbstractString, cursor) = getqualifiedname(lines(str)[cursor.line], cursor.column)
 
-function isdefinition(code::String)
+function isdefinition(code::AbstractString)
   try
     code = parse(code)
     return isexpr(code, :function) || (isexpr(code, :(=)) && isexpr(code.args[1], :call))

--- a/src/parse/scope.jl
+++ b/src/parse/scope.jl
@@ -102,7 +102,7 @@ immutable Scope
 end
 
 Scope(kind) = Scope(kind, "")
-Scope(kind::Symbol, name::String) = Scope(kind, convert(UTF8String, name))
+Scope(kind::Symbol, name::AbstractString) = Scope(kind, convert(UTF8String, name))
 Scope(kind, name) = Scope(symbol(kind), string(name))
 
 ==(a::Scope, b::Scope) = a.kind == b.kind && a.name == b.name
@@ -143,7 +143,7 @@ end
 
 # API functions
 
-Optional(T) = Union(T, Nothing)
+Optional(T) = Union{T, Void}
 
 function scopes(code::LineNumberingReader, cur::Optional(Cursor) = nothing)
   ts = Lexer.TokenStream(code)
@@ -164,11 +164,11 @@ function scopes(code::LineNumberingReader, cur::Optional(Cursor) = nothing)
   return scs
 end
 
-toLNR(s::String) = LineNumberingReader(s)
+toLNR(s::AbstractString) = LineNumberingReader(s)
 toLNR(r::LineNumberingReader) = r
 toCursor(i::Integer) = cursor(i, 1)
 toCursor(c::Cursor) = c
-toCursor(::Nothing) = nothing
+toCursor(::Void) = nothing
 
 scopes(code, cur=nothing) = scopes(toLNR(code), toCursor(cur))
 

--- a/src/utils/streams.jl
+++ b/src/utils/streams.jl
@@ -9,7 +9,7 @@ function skipwhitespace(io::IO; newlines = true)
   return io
 end
 
-function startswith(stream::IO, s::String; eat = true, padding = false)
+function startswith(stream::IO, s::AbstractString; eat = true, padding = false)
   start = position(stream)
   padding && skipwhitespace(stream)
   result = true
@@ -30,7 +30,7 @@ function startswith(stream::IO, c::Char; eat = true)
   end
 end
 
-function startswith{T<:String}(stream::IO, ss::Vector{T}; eat = true)
+function startswith{T<:AbstractString}(stream::IO, ss::Vector{T}; eat = true)
   for s in ss
     startswith(stream, s, eat = eat) && return true
   end


### PR DESCRIPTION
- `String`     -> `AbstractString` or `UTF8String`
- `Nothing`    -> `Void`
- `Union(...)` -> `Union{...}`

Also adds Compat.jl to package requirements pre-emptively for when 0.4 and 0.5 begin to diverge. I can drop this change if you'd rather not add it at the moment.
