### PR TITLE
correction for atom-julia-client #25 ?

### DIFF
--- a/src/module.jl
+++ b/src/module.jl
@@ -12,8 +12,8 @@ function readdir′(dir)
   end
 end
 
-isdir′(f) = try isdir(f) end
-isfile′(f) = try isfile(f) end
+isdir′(f) = try isdir(f) catch ; false ; end
+isfile′(f) = try isfile(f) catch ; false ; end
 
 files(dir) =
   @>> dir readdir′ map!(f->joinpath(dir, f)) filter!(isfile′)


### PR DESCRIPTION
I had the same problem as the one discribed in  JunoLab/atom-julia-client#25 with a .jl file saved in "c:/temp/", but it disappeared when moving the file to another directory.

Problem is (apparently) solved with this change to module.jl in CodeTools that makes `isdir'` and `isfilse'` return `false` instead of `nothing` when isdir or isfile throw an error.
