### PR TITLE
add Requires explicitly to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ LNR
 JuliaParser
 MacroTools
 Compat
+Requires


### PR DESCRIPTION
anything directly used (https://github.com/JunoLab/CodeTools.jl/blob/42a723a486a2c06503b97693e0a4663807ec46b8/src/CodeTools.jl#L5)
should be explicitly depended on, not assumed to be present as a transitive dep
