### PR TITLE
Fix errors pop-ups when using PyPlot

### DIFF
--- a/src/summaries.jl
+++ b/src/summaries.jl
@@ -5,6 +5,8 @@ import Base.Markdown: MD, Code, Paragraph
 # flat_content(xs::Vector) = reduce((xs, x) -> vcat(xs,flat_content(x)), [], xs)
 # flat_content(md::MD) = flat_content(md.content)
 flatten(md::MD) = MD(flat_content(md))
+flatten(arr::Array{Any,1}) = MD(flat_content!(arr))
+flatten(txt::Text{Function}) = MD(flat_content!([txt]))
 
 # Faster version
 


### PR DESCRIPTION
This change is taken directly from the following comment by @ElbaKramer: https://github.com/JunoLab/atom-julia-client/issues/121#issuecomment-200609355 in issue JunoLab/atom-julia-client#121.  Hope it helps to put @ElbaKramer's suggestion into a pull request.
