### PR TITLE
updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,21 @@
+name = "CodeTools"
+version = "0.6.5"
+uuid = "53a63b46-67e4-5edd-8c66-0af0544a99b9"
+
+[deps]
+LNR = "7c4cb9fa-83a0-5386-9231-d6167c818060"
+Lazy = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
+
+[compat]
+Lazy = "≥ 0.6.0"
+Tokenize = "≥ 0.5.3"
+julia = "≥ 0.7.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 0.7
-Lazy 0.6
-LNR
-Tokenize 0.5.3

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -17,7 +17,7 @@ const builtin_completions =
 # Module completions
 # ––––––––––––––––––
 
-const identifier_pattern = r"^@?[_\p{L}][\p{Xwd}!]*+$"
+const identifier_pattern = r"^@?[_\p{L}][\p{Xwd}′!]*+$"
 
 _names(mod; all = false, imported = false) = filter!(x -> !Base.isdeprecated(mod, Symbol(x)), names(mod, all=all, imported=imported))
 


### PR DESCRIPTION
Just add `\prime` to identifier regex (maybe there are some other Unicode characters we are missing with `\p{Xwd}`)

Noticed this package still uses REQUIER, and so also included the update for that as well.