### PR TITLE
Show conflicting package names to help debug

### DIFF
--- a/src/eval.jl
+++ b/src/eval.jl
@@ -51,7 +51,7 @@ function getpackage(mod)
   elseif length(inds) == 0
     return nothing
   else
-    @warn "no support for multiple packages with the same name yet"
+    @warn "no support for multiple packages with the same name yet (conflicting packages: $mod)"
     return get(Base.loaded_modules, first(inds), Main)
   end
 end


### PR DESCRIPTION
There's this warning (https://github.com/JunoLab/Juno.jl/issues/303):
```
┌ Warning: no support for multiple packages with the same name yet
└ @ CodeTools C:\Users\Laci\.julia\packages\CodeTools\xGemk\src\eval.jl:54
```
Would be easier to debug if the name of the packages would be printed too, something like:
```
┌ Warning: no support for multiple packages with the same name yet (conflicting packages: SignedDistanceFields)
└ @ CodeTools C:\Users\Laci\.julia\dev\CodeTools\src\eval.jl:54
```