### PR TITLE
make macros valid identifiers

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -23,7 +23,7 @@ _names(mod; all = false, imported = false) = filter!(x -> !Base.isdeprecated(mod
 
 moduleusings(mod) = ccall(:jl_module_usings, Any, (Any,), mod)
 
-filtervalid(names) = @>> names map(string) filter(Base.isidentifier)
+filtervalid(names) = @>> names map(string) filter(n -> Base.isidentifier(n) || startswith(n, '@'))
 
 accessible(mod::Module) =
   [_names(mod, all=true, imported=true);


### PR DESCRIPTION
As far as I see those existing additional identifer cases, I think allowing macro names would be suffice:
ref: https://github.com/JuliaLang/julia/blob/master/base/show.jl#L1056-L1065
ref: https://github.com/JuliaLang/julia/blob/master/base/show.jl#L1075-L1085